### PR TITLE
努力値と個体値を計算する新しい関数を追加し、ステータス計算のロジックを改善。

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { NatureInput } from "@/containers/NatureInput";
 import { natureMap, natureTypes } from "@/constants/nature";
 import { calcPokeIvEvStatus } from "@/lib/calcPokeIvEvStatus";
 import { statTypes } from "@/constants";
+import { calcPokeStatusAsString } from "@/lib/calcPokeStatusAsString";
 
 type FormState = {
   status: string;
@@ -119,20 +120,24 @@ export default function Home() {
 
   // 努力値・個体値
   useEffect(() => {
-    if (
-      JSON.stringify(ivStats) === JSON.stringify(ivStatusRef.current) &&
-      JSON.stringify(evStats) === JSON.stringify(evStatusRef.current)
-    ) {
-      return; // 変更がない場合は何もしない
-    }
-    const next = calcPokeStatusAllAsString({
-      baseStats: baseStatsRef.current,
-      ivStats,
-      evStats,
-      level: levelRef.current,
-      nature: natureRef.current,
+    const key = statTypes.find((stat) => {
+      return (
+        ivStats[stat] !== ivStatusRef.current[stat] ||
+        evStats[stat] !== evStatusRef.current[stat]
+      );
     });
-    setStatusStat(next);
+
+    if (key === undefined) return;
+
+    const changedStatus = calcPokeStatusAsString(
+      Number(baseStatsRef.current[key]),
+      Number(ivStats[key]),
+      Number(evStats[key]),
+      Number(levelRef.current),
+      Number(natureMap[natureRef.current][key]),
+      key
+    );
+    setStatusStat({ ...statusRef.current, [key]: changedStatus });
     ivStatusRef.current = { ...ivStats };
     evStatusRef.current = { ...evStats };
   }, [ivStats, evStats]);
@@ -160,7 +165,6 @@ export default function Home() {
     // 変化したステータスだけ逆算して更新
     const newIvStats = { ...ivStatusRef.current, [key]: String(iv) };
     const newEvStats = { ...evStatusRef.current, [key]: String(ev) };
-    console.log("IVs:", newIvStats, "EVs:", newEvStats);
     setIvStats(newIvStats);
     setEvStats(newEvStats);
     // 現在値をrefに保存

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,9 +7,9 @@ import { LevelInput } from "@/containers/levelInput";
 import { calcPokeStatusAllAsString } from "@/lib/calcPokeStatusAllAsString";
 import { NatureType, StatType } from "@/types";
 import { NatureInput } from "@/containers/NatureInput";
-import { NatureMap, NatureTypes } from "@/constants/nature";
+import { natureMap, natureTypes } from "@/constants/nature";
 import { calcPokeIvEvStatus } from "@/lib/calcPokeIvEvStatus";
-import { StatTypes } from "@/constants";
+import { statTypes } from "@/constants";
 
 type FormState = {
   status: string;
@@ -101,7 +101,7 @@ export default function Home() {
   // レベル変更時
   useEffect(() => {
     if (level === "") return;
-    if (!NatureTypes.includes(nature as NatureType)) return;
+    if (!natureTypes.includes(nature as NatureType)) return;
 
     const next = calcPokeStatusAllAsString({
       baseStats,
@@ -140,7 +140,7 @@ export default function Home() {
   // 実数値
   useEffect(() => {
     // どのステータスが変わったかを判定
-    const key = StatTypes.find(
+    const key = statTypes.find(
       (stat) => statusStat[stat] !== statusRef.current[stat]
     );
 
@@ -150,7 +150,7 @@ export default function Home() {
       Number(levelRef.current),
       Number(statusStat[key]),
       Number(baseStatsRef.current[key]),
-      NatureMap[natureRef.current][key],
+      natureMap[natureRef.current][key],
       key
     );
     if (!success) {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,1 +1,1 @@
-export const StatTypes = ["HP", "Atk", "Def", "SpA", "SpD", "Spe"] as const;
+export const statTypes = ["HP", "Atk", "Def", "SpA", "SpD", "Spe"] as const;

--- a/src/constants/nature.ts
+++ b/src/constants/nature.ts
@@ -1,6 +1,6 @@
 import { NatureType, StatType } from "@/types";
 
-export const NatureTypes = [
+export const natureTypes = [
   "さみしがり",
   "いじっぱり",
   "やんちゃ",
@@ -28,7 +28,7 @@ export const NatureTypes = [
   "まじめ",
 ] as const;
 
-export const NatureMap: {
+export const natureMap: {
   [key in NatureType]: { [key in StatType]: number };
 } = {
   さみしがり: {

--- a/src/containers/BaseStatInputList/BaseStatInputList.tsx
+++ b/src/containers/BaseStatInputList/BaseStatInputList.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { BaseStatInput } from "../BaseStatInput";
 import { StatType } from "@/types";
-import { StatTypes } from "@/constants";
+import { statTypes } from "@/constants";
 
 type Props = {
   values: {
@@ -21,7 +21,7 @@ function BaseStatInputList({ values, onChange }: Props) {
 
   return (
     <React.Fragment>
-      {StatTypes.map((statType) => (
+      {statTypes.map((statType) => (
         <BaseStatInput
           key={statType}
           value={values[statType]}

--- a/src/containers/EvStatInputList/EvStatInputList.tsx
+++ b/src/containers/EvStatInputList/EvStatInputList.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { StatType } from "@/types";
 import { EvStatInput } from "../EvStatInput/EvStatInput";
-import { StatTypes } from "@/constants";
+import { statTypes } from "@/constants";
 
 type Props = {
   values: {
@@ -22,7 +22,7 @@ function EvStatInputList({ values, onChange }: Props) {
 
   return (
     <React.Fragment>
-      {StatTypes.map((statType) => (
+      {statTypes.map((statType) => (
         <EvStatInput
           key={statType}
           value={values[statType]}

--- a/src/containers/IvStatInputList/IvStatInputList.tsx
+++ b/src/containers/IvStatInputList/IvStatInputList.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { IvStatInput } from "../IvStatInput/IvStatInput";
 import { StatType } from "@/types";
-import { StatTypes } from "@/constants";
+import { statTypes } from "@/constants";
 
 type Props = {
   values: {
@@ -21,7 +21,7 @@ function IvStatInputList({ values, onChange }: Props) {
 
   return (
     <React.Fragment>
-      {StatTypes.map((statType) => (
+      {statTypes.map((statType) => (
         <IvStatInput
           key={statType}
           value={values[statType]}

--- a/src/lib/calcPokeEv.ts
+++ b/src/lib/calcPokeEv.ts
@@ -8,11 +8,19 @@ function calcPokeEvStatus(
   natureMultiplier: number,
   statType: StatType
 ): { ev?: number; success: boolean } {
-  const evCandidate = Array.from({ length: 64 }, (_, i) => i * 4);
+  const evIncrement = 4; // 努力値は4の倍数で増加
+  const candidateCnt = 64; // 努力値の候補数（0から252までの4の倍数）
+  const maxIv = 31;
+
+  const evCandidate = Array.from(
+    { length: candidateCnt },
+    (_, i) => i * evIncrement
+  ); // 0から252までの努力値候補（4の倍数）
+  console.log("努力値候補:", evCandidate);
   const evs = evCandidate.filter((ev) => {
     const calcStatus = calcPokeStatus(
       base,
-      31,
+      maxIv,
       ev,
       level,
       natureMultiplier,

--- a/src/lib/calcPokeEv.ts
+++ b/src/lib/calcPokeEv.ts
@@ -1,0 +1,32 @@
+import { StatType } from "@/types";
+import { calcPokeStatus } from "./calcPokeStatus";
+
+function calcPokeEvStatus(
+  level: number,
+  status: number,
+  base: number,
+  natureMultiplier: number,
+  statType: StatType
+): { ev?: number; success: boolean } {
+  const evCandidate = Array.from({ length: 64 }, (_, i) => i * 4);
+  const evs = evCandidate.filter((ev) => {
+    const calcStatus = calcPokeStatus(
+      base,
+      31,
+      ev,
+      level,
+      natureMultiplier,
+      statType
+    );
+    return calcStatus === status;
+  });
+
+  if (evs.length === 0) {
+    return { success: false }; // 努力値が見つからない場合は0を返す
+  } else {
+    // TODO: フィルタ等の実装
+    return { ev: evs[0], success: true }; // 最小の努力値を返す
+  }
+}
+
+export { calcPokeEvStatus };

--- a/src/lib/calcPokeIv.ts
+++ b/src/lib/calcPokeIv.ts
@@ -1,0 +1,32 @@
+import { StatType } from "@/types";
+import { calcPokeStatus } from "./calcPokeStatus";
+
+function calcPokeIvStatus(
+  level: number,
+  status: number,
+  base: number,
+  natureMultiplier: number,
+  statType: StatType
+): { iv?: number; success: boolean } {
+  const ivCandidate = [...Array(32).keys()]; // 0-31の個体値候補
+  const ivs = ivCandidate.filter((iv) => {
+    const calcStatus = calcPokeStatus(
+      base,
+      iv,
+      0,
+      level,
+      natureMultiplier,
+      statType
+    );
+    return calcStatus === status;
+  });
+
+  if (ivs.length === 0) {
+    return { success: false }; // 個体値が見つからない場合
+  } else {
+    // TODO: フィルタ等の実装
+    return { iv: ivs[ivs.length - 1], success: true }; // 最大の個体値を返す
+  }
+}
+
+export { calcPokeIvStatus };

--- a/src/lib/calcPokeIvEvStatus.ts
+++ b/src/lib/calcPokeIvEvStatus.ts
@@ -14,7 +14,7 @@ function calcPokeIvEvStatus(
   const minEv = 0;
 
   // 個体値31を計算して個体値を減らすか、努力値を増やすかを確認する
-  const StatusEv0 = calcPokeStatus(
+  const statusEv0 = calcPokeStatus(
     base,
     maxIv,
     minEv,
@@ -22,7 +22,7 @@ function calcPokeIvEvStatus(
     natureMultiplier,
     statType
   );
-  if (StatusEv0 >= status) {
+  if (statusEv0 >= status) {
     const { iv, success } = calcPokeIvStatus(
       level,
       status,

--- a/src/lib/calcPokeIvEvStatus.ts
+++ b/src/lib/calcPokeIvEvStatus.ts
@@ -1,0 +1,48 @@
+import { StatType } from "@/types";
+import { calcPokeStatus } from "./calcPokeStatus";
+import { calcPokeIvStatus } from "./calcPokeIv";
+import { calcPokeEvStatus } from "./calcPokeEv";
+
+function calcPokeIvEvStatus(
+  level: number,
+  status: number,
+  base: number,
+  natureMultiplier: number,
+  statType: StatType
+): { iv?: number; ev?: number; success: boolean } {
+  const maxIv = 31;
+  const minEv = 0;
+
+  // 個体値31を計算して個体値を減らすか、努力値を増やすかを確認する
+  const StatusEv0 = calcPokeStatus(
+    base,
+    maxIv,
+    minEv,
+    level,
+    natureMultiplier,
+    statType
+  );
+  if (StatusEv0 >= status) {
+    const { iv, success } = calcPokeIvStatus(
+      level,
+      status,
+      base,
+      natureMultiplier,
+      statType
+    );
+    return success ? { iv, ev: minEv, success } : { iv, success };
+  } else {
+    // 努力値を調整する
+    const { ev, success } = calcPokeEvStatus(
+      level,
+      status,
+      base,
+      natureMultiplier,
+      statType
+    );
+
+    return success ? { iv: maxIv, ev, success } : { success: false };
+  }
+}
+
+export { calcPokeIvEvStatus };

--- a/src/lib/calcPokeStatusAll.ts
+++ b/src/lib/calcPokeStatusAll.ts
@@ -1,6 +1,6 @@
 import { NatureType } from "@/types";
 import { calcPokeStatus } from "./calcPokeStatus";
-import { NatureMap } from "@/constants/nature";
+import { natureMap } from "@/constants/nature";
 
 type Props = {
   baseStats: { [key: string]: number };
@@ -23,7 +23,7 @@ function calcPokeStatusAll({
       ivStats.HP,
       evStats.HP,
       level,
-      NatureMap[nature].HP,
+      natureMap[nature].HP,
       "HP"
     ),
     Atk: calcPokeStatus(
@@ -31,7 +31,7 @@ function calcPokeStatusAll({
       ivStats.Atk,
       evStats.Atk,
       level,
-      NatureMap[nature].Atk,
+      natureMap[nature].Atk,
       "Atk"
     ),
     Def: calcPokeStatus(
@@ -39,7 +39,7 @@ function calcPokeStatusAll({
       ivStats.Def,
       evStats.Def,
       level,
-      NatureMap[nature].Def,
+      natureMap[nature].Def,
       "Def"
     ),
     SpA: calcPokeStatus(
@@ -47,7 +47,7 @@ function calcPokeStatusAll({
       ivStats.SpA,
       evStats.SpA,
       level,
-      NatureMap[nature].SpA,
+      natureMap[nature].SpA,
       "SpA"
     ),
     SpD: calcPokeStatus(
@@ -55,7 +55,7 @@ function calcPokeStatusAll({
       ivStats.SpD,
       evStats.SpD,
       level,
-      NatureMap[nature].SpD,
+      natureMap[nature].SpD,
       "SpD"
     ),
     Spe: calcPokeStatus(
@@ -63,7 +63,7 @@ function calcPokeStatusAll({
       ivStats.Spe,
       evStats.Spe,
       level,
-      NatureMap[nature].Spe,
+      natureMap[nature].Spe,
       "Spe"
     ),
   };

--- a/src/lib/calcPokeStatusAsString.ts
+++ b/src/lib/calcPokeStatusAsString.ts
@@ -1,0 +1,22 @@
+import { StatType } from "@/types";
+import { calcPokeStatus } from "./calcPokeStatus";
+
+function calcPokeStatusAsString(
+  base: number,
+  iv: number,
+  ev: number,
+  level: number,
+  natureMultiplier: number,
+  statType: StatType
+): string {
+  return calcPokeStatus(
+    base,
+    iv,
+    ev,
+    level,
+    natureMultiplier,
+    statType
+  ).toString();
+}
+
+export { calcPokeStatusAsString };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
-import { StatTypes } from "@/constants";
-import { NatureTypes } from "@/constants/nature";
+import { statTypes } from "@/constants";
+import { natureTypes } from "@/constants/nature";
 
-export type StatType = (typeof StatTypes)[number];
-export type NatureType = (typeof NatureTypes)[number];
+export type StatType = (typeof statTypes)[number];
+export type NatureType = (typeof natureTypes)[number];


### PR DESCRIPTION
## 概要
- 実数値から個体値、努力値を逆算できるようにする

## 変更内容
逆算は個体値0-31、努力値0-252を全てステータス計算して、同じ値になるものを候補にする形で行う。
真面目に逆算しようとするとdoubleや切り捨ての処理が面倒なため。

計算の遅さは少し気になるが、利用するには問題ない程度の認識。
個体値は最大の値のものを、努力値は最小の値のものを返すようにしている。

## Copilot がレビューをする際のルール

- 日本語で記述してください、変数名やクラス名は元の名前のままにしてください
- 指摘内容のレベルを 3 つに分けてください
  - 1. must: 修正必須
  - 2. better: 修正した方が良い
  - 3. question: 確認した方が良い
