### PR TITLE
副作用で実数値の計算が上手く行っていない問題の修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState, useEffect, useRef, useState } from "react";
+import { useActionState, useEffect, useState } from "react";
 import Image from "next/image";
 import { PokeStatDisplayTable } from "@/features/PokeStatDisplayTable";
 import { LevelInput } from "@/containers/levelInput";
@@ -80,36 +80,25 @@ export default function Home() {
     Spe: "0",
   });
 
-  const levelRef = useRef(level);
-  const natureRef = useRef(nature);
-  const baseStatsRef = useRef(baseStats);
-  const statusRef = useRef(statusStat);
-  const ivStatusRef = useRef(ivStats);
-  const evStatusRef = useRef(evStats);
-
   // form受け取り時
   useEffect(() => {
     setBaseStats(state.baseStats);
   }, [state.baseStats]);
 
-  // レベル変更時
   useEffect(() => {
+    console.log("useEffect");
     if (level === "") return;
     if (!natureTypes.includes(nature as NatureType)) return;
 
     const next = calcPokeStatusAllAsString({
       baseStats,
-      ivStats: ivStatusRef.current,
-      evStats: evStatusRef.current,
+      ivStats,
+      evStats,
       level: Number(level),
       nature,
     });
-    statusRef.current = next;
-    natureRef.current = nature;
-    baseStatsRef.current = { ...baseStats };
-    levelRef.current = level;
     setStatusStat(next);
-  }, [level, nature, baseStats]);
+  }, [baseStats, ivStats, evStats, level, nature]);
 
   const handleBaseChange =
     (key: StatType) => (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -161,10 +150,10 @@ export default function Home() {
       const newStatus = { ...statusStat, [key]: e.target.value };
       setStatusStat({ ...newStatus });
       const { iv, ev, success } = calcPokeIvEvStatus(
-        Number(levelRef.current),
+        Number(level),
         Number(e.target.value),
-        Number(baseStatsRef.current[key]),
-        natureMap[natureRef.current][key],
+        Number(baseStats[key]),
+        natureMap[nature][key],
         key
       );
       if (!success) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,7 +86,6 @@ export default function Home() {
   }, [state.baseStats]);
 
   useEffect(() => {
-    console.log("useEffect");
     if (level === "") return;
     if (!natureTypes.includes(nature as NatureType)) return;
 

--- a/src/containers/levelInput/LevelInput.tsx
+++ b/src/containers/levelInput/LevelInput.tsx
@@ -8,8 +8,7 @@ type Props = {
 
 function LevelInput({ value, onChange, className }: Props) {
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    onChange(newValue);
+    onChange(e.target.value);
   };
 
   return (


### PR DESCRIPTION
## 概要
useRefを使っていた時の名残でうまく副作用で計算できていなかった問題を修正

## 変更内容
- useRefを削除
- 直接set関数を渡していたものを削除

## Memo
ポケモン名入力で種族値が切り替わったときなどは改めて実数値を計算しないといけない
→ ここは副作用として実装した方が簡潔になる。
構造上、useRefを使わない場合、evStats、ivStatsなども依存配列に含める必要がある。
要するにivStatsの変更時には副作用が発火するようになる。
ここでstatusStatsも依存配列に入れようとするとevの変更、ivの変更により副作用の無限ループになるため、
statusStatsは依存配列に入れられない。
実数値の編集はonChangeで即時的にevStats、ivStatsを編集すれば副作用の前に変更を適用できるはず。
つまり、evStatsやivStatsに関しては最初通り、set関数を渡すようにして、
実数値計算のみ明示的にhandlerを渡せば思った通りの動作をしてくれるような気がする。
が、hooksに分ける時にもっと良い手段があるかもしれないので今後の課題か。


## Copilot がレビューをする際のルール

- 日本語で記述してください、変数名やクラス名は元の名前のままにしてください
- 指摘内容のレベルを 3 つに分けてください
  - 1. must: 修正必須
  - 2. better: 修正した方が良い
  - 3. question: 確認した方が良い
