### PR TITLE
onChangeによる変更からuseEffectによる変更に修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,14 @@
 "use client";
 
-import { useActionState, useEffect, useState } from "react";
+import { useActionState, useState } from "react";
 import Image from "next/image";
 import { PokeStatDisplayTable } from "@/features/PokeStatDisplayTable";
 import { LevelInput } from "@/containers/levelInput";
-import { calcPokeStatusAllAsString } from "@/lib/calcPokeStatusAllAsString";
 import { NatureType, StatType } from "@/types";
 import { NatureInput } from "@/containers/NatureInput";
-import { natureMap, natureTypes } from "@/constants/nature";
-import { calcPokeIvEvStatus } from "@/lib/calcPokeIvEvStatus";
-import { calcPokeStatusAsString } from "@/lib/calcPokeStatusAsString";
 import { PokeNameInput } from "@/containers/PokeNameInput";
 import { Button } from "@/components/Button";
+import { useStatus } from "@/hooks/useStatus";
 
 type FormState = {
   status: string;
@@ -42,140 +39,43 @@ export default function Home() {
   const [level, setLevel] = useState<string>("50");
   const [nature, setNature] = useState<NatureType>("がんばりや");
 
-  const [baseStats, setBaseStats] = useState<{ [key in StatType]: string }>({
-    HP: "0",
-    Atk: "0",
-    Def: "0",
-    SpA: "0",
-    SpD: "0",
-    Spe: "0",
-  });
-
-  const [ivStats, setIvStats] = useState<{ [key in StatType]: string }>({
-    HP: "31",
-    Atk: "31",
-    Def: "31",
-    SpA: "31",
-    SpD: "31",
-    Spe: "31",
-  });
-
-  const [evStats, setEvStats] = useState<{ [key in StatType]: string }>({
-    HP: "0",
-    Atk: "0",
-    Def: "0",
-    SpA: "0",
-    SpD: "0",
-    Spe: "0",
-  });
-
-  const [statusStat, setStatusStat] = useState<{
-    [key in StatType]: string;
-  }>({
-    HP: "0",
-    Atk: "0",
-    Def: "0",
-    SpA: "0",
-    SpD: "0",
-    Spe: "0",
-  });
-
-  const [statusError, setStatusError] = useState<{
-    [key in StatType]: boolean;
-  }>({
-    HP: false,
-    Atk: false,
-    Def: false,
-    SpA: false,
-    SpD: false,
-    Spe: false,
-  });
-
-  // form受け取り時
-  useEffect(() => {
-    setBaseStats(state.baseStats);
-  }, [state.baseStats]);
-
-  useEffect(() => {
-    if (level === "") return;
-    if (!natureTypes.includes(nature as NatureType)) return;
-
-    const next = calcPokeStatusAllAsString({
-      baseStats,
-      ivStats,
-      evStats,
+  const status = {
+    HP: useStatus({
+      stat: "HP",
       level: Number(level),
       nature,
-    });
-    setStatusStat(next);
-  }, [baseStats, ivStats, evStats, level, nature]);
-
-  const handleBaseChange =
-    (key: StatType) => (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newBaseStats = { ...baseStats, [key]: e.target.value };
-      setBaseStats(newBaseStats);
-      const changedStatus = calcPokeStatusAsString(
-        Number(e.target.value),
-        Number(ivStats[key]),
-        Number(evStats[key]),
-        Number(level),
-        Number(natureMap[nature][key]),
-        key
-      );
-      setStatusStat({ ...statusStat, [key]: changedStatus });
-    };
-
-  const handleIvChange = (key: StatType) => {
-    return (e: React.ChangeEvent<HTMLInputElement>) => {
-      setIvStats({ ...ivStats, [key]: e.target.value });
-      const changedStatus = calcPokeStatusAsString(
-        Number(baseStats[key]),
-        Number(e.target.value),
-        Number(evStats[key]),
-        Number(level),
-        Number(natureMap[nature][key]),
-        key
-      );
-      setStatusStat({ ...statusStat, [key]: changedStatus });
-    };
-  };
-
-  const handleEvChange = (key: StatType) => {
-    return (e: React.ChangeEvent<HTMLInputElement>) => {
-      setEvStats({ ...evStats, [key]: e.target.value });
-      const changedStatus = calcPokeStatusAsString(
-        Number(baseStats[key]),
-        Number(ivStats[key]),
-        Number(e.target.value),
-        Number(level),
-        Number(natureMap[nature][key]),
-        key
-      );
-      setStatusStat({ ...statusStat, [key]: changedStatus });
-    };
-  };
-
-  const handleStatusChange = (key: StatType) => {
-    return (e: React.ChangeEvent<HTMLInputElement>) => {
-      const newStatus = { ...statusStat, [key]: e.target.value };
-      setStatusStat({ ...newStatus });
-      const { iv, ev, success } = calcPokeIvEvStatus(
-        Number(level),
-        Number(e.target.value),
-        Number(baseStats[key]),
-        natureMap[nature][key],
-        key
-      );
-      setStatusError({ ...statusError, [key]: !success });
-      if (!success) {
-        return;
-      }
-      // 変化したステータスだけ逆算して更新
-      const newIvStats = { ...ivStats, [key]: String(iv) };
-      const newEvStats = { ...evStats, [key]: String(ev) };
-      setIvStats(newIvStats);
-      setEvStats(newEvStats);
-    };
+      actionState: state.baseStats.HP,
+    }),
+    Atk: useStatus({
+      stat: "Atk",
+      level: Number(level),
+      nature,
+      actionState: state.baseStats.Atk,
+    }),
+    Def: useStatus({
+      stat: "Def",
+      level: Number(level),
+      nature,
+      actionState: state.baseStats.Def,
+    }),
+    SpA: useStatus({
+      stat: "SpA",
+      level: Number(level),
+      nature,
+      actionState: state.baseStats.SpA,
+    }),
+    SpD: useStatus({
+      stat: "SpD",
+      level: Number(level),
+      nature,
+      actionState: state.baseStats.SpD,
+    }),
+    Spe: useStatus({
+      stat: "Spe",
+      level: Number(level),
+      nature,
+      actionState: state.baseStats.Spe,
+    }),
   };
 
   return (
@@ -205,17 +105,7 @@ export default function Home() {
           </label>
         </div>
       </div>
-      <PokeStatDisplayTable
-        baseStats={baseStats}
-        ivStats={ivStats}
-        evStats={evStats}
-        statusStat={statusStat}
-        statusError={statusError}
-        handleStatusChange={handleStatusChange}
-        handleEvChange={handleEvChange}
-        handleIvChange={handleIvChange}
-        handleBaseChange={handleBaseChange}
-      />
+      <PokeStatDisplayTable status={status} />
     </div>
   );
 }

--- a/src/containers/BaseStatInputList/BaseStatInputList.tsx
+++ b/src/containers/BaseStatInputList/BaseStatInputList.tsx
@@ -7,9 +7,9 @@ type Props = {
   values: {
     [key in StatType]: string;
   };
-  handleBaseChange: (
-    key: StatType
-  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleBaseChange: {
+    [key in StatType]: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  };
 };
 
 function BaseStatInputList({ values, handleBaseChange }: Props) {
@@ -19,7 +19,7 @@ function BaseStatInputList({ values, handleBaseChange }: Props) {
         <BaseStatInput
           key={statType}
           value={values[statType]}
-          onChange={handleBaseChange(statType)}
+          onChange={handleBaseChange[statType]}
         ></BaseStatInput>
       ))}
     </React.Fragment>

--- a/src/containers/EvStatInputList/EvStatInputList.tsx
+++ b/src/containers/EvStatInputList/EvStatInputList.tsx
@@ -8,9 +8,9 @@ type Props = {
   values: {
     [key in StatType]: string;
   };
-  handleEvChange: (
-    key: StatType
-  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleEvChange: {
+    [key in StatType]: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  };
 };
 
 function EvStatInputList({ values, handleEvChange }: Props) {
@@ -20,7 +20,7 @@ function EvStatInputList({ values, handleEvChange }: Props) {
         <EvStatInput
           key={statType}
           value={values[statType]}
-          onChange={handleEvChange(statType)}
+          onChange={handleEvChange[statType]}
         ></EvStatInput>
       ))}
     </React.Fragment>

--- a/src/containers/IvStatInputList/IvStatInputList.tsx
+++ b/src/containers/IvStatInputList/IvStatInputList.tsx
@@ -7,9 +7,9 @@ type Props = {
   values: {
     [key in StatType]: string;
   };
-  handleIvChange: (
-    key: StatType
-  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleIvChange: {
+    [key in StatType]: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  };
 };
 
 function IvStatInputList({ values, handleIvChange }: Props) {
@@ -19,7 +19,7 @@ function IvStatInputList({ values, handleIvChange }: Props) {
         <IvStatInput
           key={statType}
           value={values[statType]}
-          onChange={handleIvChange(statType)}
+          onChange={handleIvChange[statType]}
         ></IvStatInput>
       ))}
     </React.Fragment>

--- a/src/containers/StatusStatInputList/StatusStatInputList.tsx
+++ b/src/containers/StatusStatInputList/StatusStatInputList.tsx
@@ -1,14 +1,15 @@
 import React from "react";
 import { StatusStatInput } from "../StatusStatInput";
 import { StatType } from "@/types";
+import { statTypes } from "@/constants";
 
 type Props = {
   values: {
     [key in StatType]: string;
   };
-  handleStatusChange: (
-    key: StatType
-  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleStatusChange: {
+    [key in StatType]: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  };
   statusError: {
     [key in StatType]: boolean;
   };
@@ -21,36 +22,14 @@ function StatusStatInputList({
 }: Props) {
   return (
     <React.Fragment>
-      <StatusStatInput
-        value={values["HP"]}
-        onChange={handleStatusChange("HP")}
-        isError={statusError["HP"]}
-      ></StatusStatInput>
-      <StatusStatInput
-        value={values["Atk"]}
-        onChange={handleStatusChange("Atk")}
-        isError={statusError["Atk"]}
-      ></StatusStatInput>
-      <StatusStatInput
-        value={values["Def"]}
-        onChange={handleStatusChange("Def")}
-        isError={statusError["Def"]}
-      ></StatusStatInput>
-      <StatusStatInput
-        value={values["SpA"]}
-        onChange={handleStatusChange("SpA")}
-        isError={statusError["SpA"]}
-      ></StatusStatInput>
-      <StatusStatInput
-        value={values["SpD"]}
-        onChange={handleStatusChange("SpD")}
-        isError={statusError["SpD"]}
-      ></StatusStatInput>
-      <StatusStatInput
-        value={values["Spe"]}
-        onChange={handleStatusChange("Spe")}
-        isError={statusError["Spe"]}
-      ></StatusStatInput>
+      {statTypes.map((statType) => (
+        <StatusStatInput
+          key={statType}
+          value={values[statType]}
+          onChange={handleStatusChange[statType]}
+          isError={statusError[statType]}
+        ></StatusStatInput>
+      ))}
     </React.Fragment>
   );
 }

--- a/src/features/PokeStatDisplayTable/PokeStatDisplayTable.tsx
+++ b/src/features/PokeStatDisplayTable/PokeStatDisplayTable.tsx
@@ -5,56 +5,85 @@ import { EvStatInputList } from "@/containers/EvStatInputList";
 import { StatusStatInputList } from "@/containers/StatusStatInputList";
 import { StatType } from "@/types";
 import { statTypes } from "@/constants";
+import { StatusHook } from "@/hooks/useStatus";
 
 type Props = {
-  baseStats: {
-    [key in StatType]: string;
-  };
-  ivStats: {
-    [key in StatType]: string;
-  };
-  evStats: {
-    [key in StatType]: string;
-  };
-  statusStat: {
-    [key in StatType]: string;
-  };
-  statusError: {
-    [key in StatType]: boolean;
-  };
-  handleStatusChange: (
-    key: StatType
-  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleEvChange: (
-    key: StatType
-  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleIvChange: (
-    key: StatType
-  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
-  handleBaseChange: (
-    key: StatType
-  ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  status: { [key in StatType]: StatusHook };
 };
 
-function PokeStatDisplayTable({
-  baseStats,
-  ivStats,
-  evStats,
-  statusStat,
-  statusError,
-  handleStatusChange,
-  handleEvChange,
-  handleIvChange,
-  handleBaseChange,
-}: Props) {
-  const baseTotal = Object.values(baseStats).reduce(
-    (acc, cur) => acc + Number(cur),
+function PokeStatDisplayTable({ status }: Props) {
+  const baseTotal = Object.values(status).reduce(
+    (acc, cur) => acc + Number(cur.base),
     0
   );
-  const evTotal = Object.values(evStats).reduce(
-    (acc, cur) => acc + Number(cur),
+  const evTotal = Object.values(status).reduce(
+    (acc, cur) => acc + Number(cur.ev),
     0
   );
+
+  const statusList = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.status,
+    }),
+    {}
+  ) as { [key in StatType]: string };
+  const evList = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.ev,
+    }),
+    {}
+  ) as { [key in StatType]: string };
+  const ivList = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.iv,
+    }),
+    {}
+  ) as { [key in StatType]: string };
+  const baseList = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.base,
+    }),
+    {}
+  ) as { [key in StatType]: string };
+  const handleStatusList = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.handleStatusChange,
+    }),
+    {}
+  ) as { [key in StatType]: (e: React.ChangeEvent<HTMLInputElement>) => void };
+  const handleEvList = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.handleEvChange,
+    }),
+    {}
+  ) as { [key in StatType]: (e: React.ChangeEvent<HTMLInputElement>) => void };
+  const handleIvList = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.handleIvChange,
+    }),
+    {}
+  ) as { [key in StatType]: (e: React.ChangeEvent<HTMLInputElement>) => void };
+  const handleBaseList = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.handleBaseChange,
+    }),
+    {}
+  ) as { [key in StatType]: (e: React.ChangeEvent<HTMLInputElement>) => void };
+  const statusError = Object.values(status).reduce(
+    (acc, cur) => ({
+      ...acc,
+      [cur.stat]: cur.isError,
+    }),
+    {}
+  ) as { [key in StatType]: boolean };
 
   return (
     <div className="grid grid-rows-8 gap-4 grid-flow-col w-[370px]">
@@ -65,22 +94,19 @@ function PokeStatDisplayTable({
       <div>合計</div>
       <div>実数値</div>
       <StatusStatInputList
-        values={statusStat}
-        handleStatusChange={handleStatusChange}
+        values={statusList}
+        handleStatusChange={handleStatusList}
         statusError={statusError}
       />
       <div></div>
       <div>努力値</div>
-      <EvStatInputList values={evStats} handleEvChange={handleEvChange} />
+      <EvStatInputList values={evList} handleEvChange={handleEvList} />
       <div>{evTotal}</div>
       <div>個体値</div>
-      <IvStatInputList values={ivStats} handleIvChange={handleIvChange} />
+      <IvStatInputList values={ivList} handleIvChange={handleIvList} />
       <div></div>
       <div>種族値</div>
-      <BaseStatInputList
-        values={baseStats}
-        handleBaseChange={handleBaseChange}
-      />
+      <BaseStatInputList values={baseList} handleBaseChange={handleBaseList} />
       <div>{baseTotal}</div>
     </div>
   );

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -1,0 +1,116 @@
+import { natureMap, natureTypes } from "@/constants/nature";
+import { calcPokeIvEvStatus } from "@/lib/calcPokeIvEvStatus";
+import { calcPokeStatusAsString } from "@/lib/calcPokeStatusAsString";
+import { NatureType, StatType } from "@/types";
+import { useEffect, useRef, useState } from "react";
+
+type Props = {
+  stat: StatType;
+  level: number;
+  nature: NatureType;
+  actionState: string;
+};
+
+export type StatusHook = {
+  stat: StatType;
+  status: string;
+  ev: string;
+  iv: string;
+  base: string;
+  isError: boolean;
+  handleStatusChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleEvChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleIvChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleBaseChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  handleIsErrorChange: (e: boolean) => void;
+};
+
+const useStatus = ({ stat, level, nature, actionState }: Props) => {
+  const [status, setStatus] = useState<string>("");
+  const [ev, setEv] = useState<string>("0");
+  const [iv, setIv] = useState<string>("31");
+  const [base, setBaseStats] = useState("0");
+  const [isError, setIsError] = useState<boolean>(false);
+
+  const handleStatusChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setStatus(e.target.value);
+  };
+  const handleEvChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setEv(e.target.value);
+  };
+  const handleIvChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setIv(e.target.value);
+  };
+  const handleBaseChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setBaseStats(e.target.value);
+  };
+  const handleIsErrorChange = (e: boolean) => {
+    setIsError(e);
+  };
+
+  const statusRef = useRef<string>(status);
+  const evRef = useRef<string>(ev);
+  const ivRef = useRef<string>(iv);
+  const baseRef = useRef<string>(base);
+
+  useEffect(() => {
+    setBaseStats(actionState);
+  }, [actionState]);
+
+  useEffect(() => {
+    if (!natureTypes.includes(nature as NatureType)) return;
+    if (statusRef.current !== status) {
+      // 努力値、個体値の更新
+      const {
+        iv: newIv,
+        ev: newEv,
+        success,
+      } = calcPokeIvEvStatus(
+        level,
+        Number(status),
+        Number(base),
+        natureMap[nature][stat],
+        stat
+      );
+      if (!success) {
+        // 努力値、個体値が計算できなかった場合はエラー状態にする
+        handleIsErrorChange(true);
+        statusRef.current = status;
+        return;
+      }
+      handleIsErrorChange(false);
+      setEv(newEv!.toString());
+      setIv(newIv!.toString());
+    } else {
+      const changedStatus = calcPokeStatusAsString(
+        Number(base),
+        Number(iv),
+        Number(ev),
+        Number(level),
+        natureMap[nature][stat],
+        stat
+      );
+      setStatus(changedStatus);
+    }
+    statusRef.current = status;
+    baseRef.current = base;
+    evRef.current = ev;
+    ivRef.current = iv;
+  }, [status, ev, iv, base, level, nature, stat]);
+
+  return {
+    stat,
+    status,
+    ev,
+    iv,
+    base,
+    isError,
+    handleStatusChange,
+    handleEvChange,
+    handleIvChange,
+    handleBaseChange,
+    handleIsErrorChange,
+  };
+};
+
+export { useStatus };


### PR DESCRIPTION
## 概要

- close https://github.com/souldew/pokemon-stat-calculator/issues/22

元々、useEffectで実装するつもりだったが、無限ループに陥ることがあったためonClickで発火するようにしていた。
しかし、ステータスのエラーを検知する処理を追加する際にonClickごとに実装する必要になり面倒。
そのため副作用で実施に変更する。
実装自体はとりあえずRefを使って、statusが変更されたか、それ以外が変更されたかを検知しそれに応じて変更を走らせる形にして実装。



## 変更内容
StatusのuseStateをカスタムフック化
合わせて、実数値、努力値、個体値、種族値で管理していたものを、HABCDSのステータスごとに扱うように変更。
ステータス計算の大部分のロジックの見通しが良くなった。



## Copilot がレビューをする際のルール

- 日本語で記述してください、変数名やクラス名は元の名前のままにしてください
- 指摘内容のレベルを 3 つに分けてください
  - 1. must: 修正必須
  - 2. better: 修正した方が良い
  - 3. question: 確認した方が良い
