### PR TITLE
最低値、最大値を超えた時は背景を赤にする

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -80,6 +80,17 @@ export default function Home() {
     Spe: "0",
   });
 
+  const [statusError, setStatusError] = useState<{
+    [key in StatType]: boolean;
+  }>({
+    HP: false,
+    Atk: false,
+    Def: false,
+    SpA: false,
+    SpD: false,
+    Spe: false,
+  });
+
   // form受け取り時
   useEffect(() => {
     setBaseStats(state.baseStats);
@@ -155,6 +166,7 @@ export default function Home() {
         natureMap[nature][key],
         key
       );
+      setStatusError({ ...statusError, [key]: !success });
       if (!success) {
         return;
       }
@@ -198,6 +210,7 @@ export default function Home() {
         ivStats={ivStats}
         evStats={evStats}
         statusStat={statusStat}
+        statusError={statusError}
         handleStatusChange={handleStatusChange}
         handleEvChange={handleEvChange}
         handleIvChange={handleIvChange}

--- a/src/containers/StatusStatInput/StatusStatInput.tsx
+++ b/src/containers/StatusStatInput/StatusStatInput.tsx
@@ -2,9 +2,13 @@ type Props = {
   value: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
   className?: string;
+  isError: boolean;
 };
 
-function StatusStatInput({ value, onChange, className }: Props) {
+function StatusStatInput({ value, onChange, isError, className }: Props) {
+  if (isError) {
+    className = `${className} bg-red-100 border-red-300`;
+  }
   return (
     <input
       type="number"

--- a/src/containers/StatusStatInputList/StatusStatInputList.tsx
+++ b/src/containers/StatusStatInputList/StatusStatInputList.tsx
@@ -9,34 +9,47 @@ type Props = {
   handleStatusChange: (
     key: StatType
   ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
+  statusError: {
+    [key in StatType]: boolean;
+  };
 };
 
-function StatusStatInputList({ values, handleStatusChange }: Props) {
+function StatusStatInputList({
+  values,
+  handleStatusChange,
+  statusError,
+}: Props) {
   return (
     <React.Fragment>
       <StatusStatInput
         value={values["HP"]}
         onChange={handleStatusChange("HP")}
+        isError={statusError["HP"]}
       ></StatusStatInput>
       <StatusStatInput
         value={values["Atk"]}
         onChange={handleStatusChange("Atk")}
+        isError={statusError["Atk"]}
       ></StatusStatInput>
       <StatusStatInput
         value={values["Def"]}
         onChange={handleStatusChange("Def")}
+        isError={statusError["Def"]}
       ></StatusStatInput>
       <StatusStatInput
         value={values["SpA"]}
         onChange={handleStatusChange("SpA")}
+        isError={statusError["SpA"]}
       ></StatusStatInput>
       <StatusStatInput
         value={values["SpD"]}
         onChange={handleStatusChange("SpD")}
+        isError={statusError["SpD"]}
       ></StatusStatInput>
       <StatusStatInput
         value={values["Spe"]}
         onChange={handleStatusChange("Spe")}
+        isError={statusError["Spe"]}
       ></StatusStatInput>
     </React.Fragment>
   );

--- a/src/features/PokeStatDisplayTable/PokeStatDisplayTable.tsx
+++ b/src/features/PokeStatDisplayTable/PokeStatDisplayTable.tsx
@@ -19,6 +19,9 @@ type Props = {
   statusStat: {
     [key in StatType]: string;
   };
+  statusError: {
+    [key in StatType]: boolean;
+  };
   handleStatusChange: (
     key: StatType
   ) => (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -38,6 +41,7 @@ function PokeStatDisplayTable({
   ivStats,
   evStats,
   statusStat,
+  statusError,
   handleStatusChange,
   handleEvChange,
   handleIvChange,
@@ -63,6 +67,7 @@ function PokeStatDisplayTable({
       <StatusStatInputList
         values={statusStat}
         handleStatusChange={handleStatusChange}
+        statusError={statusError}
       />
       <div></div>
       <div>努力値</div>

--- a/src/lib/calcPokeIvEvStatus.ts
+++ b/src/lib/calcPokeIvEvStatus.ts
@@ -22,6 +22,8 @@ function calcPokeIvEvStatus(
     natureMultiplier,
     statType
   );
+
+  // 努力値0のよりも能力値が小さい場合は個体値を調整する
   if (statusEv0 >= status) {
     const { iv, success } = calcPokeIvStatus(
       level,


### PR DESCRIPTION
## 概要

努力値、個体値の変更で実現できないステータスになった場合は能力値の背景を赤くして警告する。

努力値、個体値の入力によるステータス変更では実現できないことはないため赤くなるのはステータスを変更した場合で、実現できない値の場合のみ。

性格を変えて実現できるでも赤くなるようにしている。

赤くなる場合
- 上昇補正で11n-1
- 性格変更による実現範囲は計算しない
- 現在の性格で実現できないほど小さい実数値、大きい実数値

## 変更内容

## Copilot がレビューをする際のルール

- 日本語で記述してください、変数名やクラス名は元の名前のままにしてください
- 指摘内容のレベルを 3 つに分けてください
  - 1. must: 修正必須
  - 2. better: 修正した方が良い
  - 3. question: 確認した方が良い
