### PR TITLE
努力値で252を入力する際副作用が走ってしまうバグを修正

### DIFF
--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -81,7 +81,15 @@ const useStatus = ({ stat, level, nature, actionState }: Props) => {
       handleIsErrorChange(false);
       setEv(newEv!.toString());
       setIv(newIv!.toString());
-    } else {
+      statusRef.current = status;
+      baseRef.current = base;
+      evRef.current = newEv!.toString();
+      ivRef.current = newIv!.toString();
+    } else if (
+      evRef.current !== ev ||
+      ivRef.current !== iv ||
+      baseRef.current !== base
+    ) {
       const changedStatus = calcPokeStatusAsString(
         Number(base),
         Number(iv),
@@ -91,11 +99,11 @@ const useStatus = ({ stat, level, nature, actionState }: Props) => {
         stat
       );
       setStatus(changedStatus);
+      statusRef.current = changedStatus;
+      baseRef.current = base;
+      evRef.current = ev;
+      ivRef.current = iv;
     }
-    statusRef.current = status;
-    baseRef.current = base;
-    evRef.current = ev;
-    ivRef.current = iv;
   }, [status, ev, iv, base, level, nature, stat]);
 
   return {


### PR DESCRIPTION
## 概要

252を入力する際に、25を入力した時点でステータス計算の副作用→努力値計算の副作用が発生することで、20になり、252を入力できないようになってしまっていた。

## 変更内容
副作用が努力値入力時、能力値入力時に副作用が走らないように修正


## Copilot がレビューをする際のルール

- 日本語で記述してください、変数名やクラス名は元の名前のままにしてください
- 指摘内容のレベルを 3 つに分けてください
  - 1. must: 修正必須
  - 2. better: 修正した方が良い
  - 3. question: 確認した方が良い
