### PR TITLE
useEffectからonChange方式に戻す

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -42,37 +42,37 @@ export default function Home() {
   const status = {
     HP: useStatus({
       stat: "HP",
-      level: Number(level),
+      level: level,
       nature,
       actionState: state.baseStats.HP,
     }),
     Atk: useStatus({
       stat: "Atk",
-      level: Number(level),
+      level: level,
       nature,
       actionState: state.baseStats.Atk,
     }),
     Def: useStatus({
       stat: "Def",
-      level: Number(level),
+      level: level,
       nature,
       actionState: state.baseStats.Def,
     }),
     SpA: useStatus({
       stat: "SpA",
-      level: Number(level),
+      level: level,
       nature,
       actionState: state.baseStats.SpA,
     }),
     SpD: useStatus({
       stat: "SpD",
-      level: Number(level),
+      level: level,
       nature,
       actionState: state.baseStats.SpD,
     }),
     Spe: useStatus({
       stat: "Spe",
-      level: Number(level),
+      level: level,
       nature,
       actionState: state.baseStats.Spe,
     }),


### PR DESCRIPTION
## 概要
- https://github.com/souldew/pokemon-stat-calculator/pull/28

上記でonChangeからuseEffectに変更した際に性格を変更したタイミングでステータスが計算されなくなっていた。
管理にuseRefを多用しているなど面倒な部分が多いためonChangeの変更に戻す。

## 変更内容
useEffectからonChangeに戻すのと同時に性格を変更した場合にステータスが修正されるようにする。

## Copilot がレビューをする際のルール

- 日本語で記述してください、変数名やクラス名は元の名前のままにしてください
- 指摘内容のレベルを 3 つに分けてください
  - 1. must: 修正必須
  - 2. better: 修正した方が良い
  - 3. question: 確認した方が良い
